### PR TITLE
Bug/fix missing routesettings warnings

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,7 +46,6 @@ You can override the default route settings/account defaults by configuring at t
 
 ```yml
 functions:
-  # Inherits the default throttle rate limits.
   hello:
     handler: src/throttle_me.handler
     events:

--- a/src/stageSettings.js
+++ b/src/stageSettings.js
@@ -9,7 +9,7 @@ const RouteSettings = require('./routeSettings');
 class StageSettings {
 
   constructor(serverless) {
-    if (!get(serverless, 'service.custom.httpApiRouteSettings')) {
+    if (!get(serverless, `service.custom.${config.key}`)) {
       serverless.cli.log(`[${config.app}] Warning: No default Route Settings have been provided.`);
     }
 
@@ -39,7 +39,7 @@ class StageSettings {
     }
 
     if (this.routeSettings.length === 0) {
-      serverless.cli.log(`[${config.app}] Warning: No Route settings have been provided.`)
+      serverless.cli.log(`[${config.app}] Warning: No RouteSettings have been provided to override the DefaultRouteSettings.`)
     }
   }
 


### PR DESCRIPTION
Resolves #1 

- Warning: No default Route Settings have been provided.
This is solved, the warning only displays when DefaultRouteSettings are not configured.

- Warning: No Route settings have been provided.
This warning is correct, but has been changed to "Warning: No RouteSettings have been provided to override the DefaultRouteSettings.", to make it more obvious.